### PR TITLE
update schema extension plugin, remove extra dir in image path

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -80,6 +80,10 @@ exports.createPages = ({ actions, graphql }) => {
 exports.createSchemaCustomization = ({ actions }) => {
 	const { createTypes } = actions;
 
+	/**
+	 * You can also do this:
+	 * imageUrl: File @fileByAbsolutePath(path: "static/img")
+	 */
 	const typeDefs = `
 		type ProductsYaml implements Node @infer {
 			testString: String

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "gatsby-plugin-sharp": "2.6.19",
     "gatsby-remark-images": "3.3.19",
     "gatsby-remark-relative-images": "0.3.0",
-    "gatsby-schema-field-absolute-path": "1.1.1",
+    "gatsby-schema-field-absolute-path": "^1.1.2",
     "gatsby-source-filesystem": "2.3.19",
     "gatsby-transformer-remark": "2.8.25",
     "gatsby-transformer-sharp": "2.5.11",

--- a/src/pages/products/page-1.yml
+++ b/src/pages/products/page-1.yml
@@ -1,5 +1,5 @@
 frontmatter:
   templateKey: product-page
 title: page 1
-imageUrl: /img/testpattern-hd-1080.jpg
+imageUrl: testpattern-hd-1080.jpg
 testString: page 1 test string

--- a/src/pages/products/page-2.yml
+++ b/src/pages/products/page-2.yml
@@ -1,5 +1,5 @@
 frontmatter:
   templateKey: product-page
 title: page 2
-imageUrl: /img/testpattern-hd-1080.jpg
+imageUrl: testpattern-hd-1080.jpg
 testString: page 2 test string

--- a/src/templates/product-page.js
+++ b/src/templates/product-page.js
@@ -4,11 +4,13 @@ import Layout from '../components/layout';
 
 const ProductPage = ({ data }) => {
 	console.log(data.productsYaml);
-
+	const imgSrc = data.productsYaml.imageUrl.childImageSharp.resize.src
 	return (
 		<Layout>
 			<h1>Product page</h1>
-			<p>Please check console. Image is coming back as <strong>null</strong>.</p>
+			<p>Please check console. Image is coming back as <strong>{imgSrc}</strong>.</p>
+
+			<img style={{ maxWidth: '100%' }} src={imgSrc} alt="product" />
 		</Layout>
 	);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6052,10 +6052,10 @@ gatsby-remark-relative-images@0.3.0:
     slash "^2.0.0"
     unist-util-select "^1.5.0"
 
-gatsby-schema-field-absolute-path@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/gatsby-schema-field-absolute-path/-/gatsby-schema-field-absolute-path-1.1.1.tgz#27182835a58d700e3fd20b2e60148283062c8ea7"
-  integrity sha512-Q8E+S4yap+2cZJuY0jkMb9rJ2tUcNB5Bt2I38mFD2cRakU7SITyxCVadlfgh3ZhVr5CLBnRtUqgHeFV8XheLKA==
+gatsby-schema-field-absolute-path@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/gatsby-schema-field-absolute-path/-/gatsby-schema-field-absolute-path-1.1.2.tgz#7f46c186b56d31cd2de69a5813ba5da67d97e367"
+  integrity sha512-vRmTc1mmEIZJ7d2JycETil5nzSFlmv7nYHEXXk3/5TAr/teUZyG5nBJ9vMKIXwdu9+/Ss2yYqUjo5MGX/7dZ3Q==
 
 gatsby-source-filesystem@2.3.19:
   version "2.3.19"


### PR DESCRIPTION
Hi Daniel!

2 issues:
- Gatsby changed the `runQuery` API since I last used my plugin — I knew about it, but hadn't had the chance to fix it so thank you for the push (d4rekanguok/gatsby-schema-field-absolute-path#4). I've published a new patch.
- I spotted an extra `/img/` path in your yaml's file image path

Applying these two fixes stuff on my end. Let me know if you have further q's!